### PR TITLE
Refactor: custom errors for wasm-storage module

### DIFF
--- a/x/wasm-storage/types/errors.go
+++ b/x/wasm-storage/types/errors.go
@@ -4,12 +4,12 @@ import errorsmod "cosmossdk.io/errors"
 
 // x/wasm-storage module sentinel errors
 var (
-	ErrDataRequestWasmExists   = errorsmod.Register(ModuleName, 1, "data Request Wasm with given hash already exists")
-	ErrOverlayWasmExists       = errorsmod.Register(ModuleName, 2, "overlay Wasm with given hash already exists")
-	ErrInvalidAuthorityAddress = errorsmod.Register(ModuleName, 3, "invalid authority address")
-	ErrInvalidAuthority        = errorsmod.Register(ModuleName, 4, "invalid authority")
-	ErrInvalidSenderAddress    = errorsmod.Register(ModuleName, 5, "invalid sender address")
-	ErrInvalidAdminAddress     = errorsmod.Register(ModuleName, 6, "invalid admin address")
-	ErrWasmNotGzipCompressed   = errorsmod.Register(ModuleName, 7, "wasm is not gzip compressed")
-	ErrInstantiateContract     = errorsmod.Register(ModuleName, 8, "error during contract instantiation")
+	ErrDataRequestWasmExists   = errorsmod.Register(ModuleName, 2, "data Request Wasm with given hash already exists")
+	ErrOverlayWasmExists       = errorsmod.Register(ModuleName, 3, "overlay Wasm with given hash already exists")
+	ErrInvalidAuthorityAddress = errorsmod.Register(ModuleName, 4, "invalid authority address")
+	ErrInvalidAuthority        = errorsmod.Register(ModuleName, 5, "invalid authority")
+	ErrInvalidSenderAddress    = errorsmod.Register(ModuleName, 6, "invalid sender address")
+	ErrInvalidAdminAddress     = errorsmod.Register(ModuleName, 7, "invalid admin address")
+	ErrWasmNotGzipCompressed   = errorsmod.Register(ModuleName, 8, "wasm is not gzip compressed")
+	ErrInstantiateContract     = errorsmod.Register(ModuleName, 9, "error during contract instantiation")
 )

--- a/x/wasm-storage/types/errors.go
+++ b/x/wasm-storage/types/errors.go
@@ -1,0 +1,15 @@
+package types
+
+import errorsmod "cosmossdk.io/errors"
+
+// x/wasm-storage module sentinel errors
+var (
+	ErrDataRequestWasmExists   = errorsmod.Register(ModuleName, 1, "data Request Wasm with given hash already exists")
+	ErrOverlayWasmExists       = errorsmod.Register(ModuleName, 2, "overlay Wasm with given hash already exists")
+	ErrInvalidAuthorityAddress = errorsmod.Register(ModuleName, 3, "invalid authority address")
+	ErrInvalidAuthority        = errorsmod.Register(ModuleName, 4, "invalid authority")
+	ErrInvalidSenderAddress    = errorsmod.Register(ModuleName, 5, "invalid sender address")
+	ErrInvalidAdminAddress     = errorsmod.Register(ModuleName, 6, "invalid admin address")
+	ErrWasmNotGzipCompressed   = errorsmod.Register(ModuleName, 7, "wasm is not gzip compressed")
+	ErrInstantiateContract     = errorsmod.Register(ModuleName, 8, "error during contract instantiation")
+)


### PR DESCRIPTION
# Explanation of Changes

Modules are encouraged to define and register their own errors to provide better context for failed messages or handler executions. Errors should be common or general errors, which can be further wrapped to provide additional specific execution context.
Modules should define and register their custom errors in x/{module}/errors.go. Registration of errors is handled via the types/errors package.
https://github.com/cosmos/cosmos-sdk/blob/main/types/errors/errors.go